### PR TITLE
Add Vary: Accept-Language header with language-specific pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ No resources.
 | <a name="input_purge_auth"></a> [purge\_auth](#input\_purge\_auth) | Whether to require API tokens when subimtting HTTP PURGE requests | `bool` | `true` | no |
 | <a name="input_shield_region"></a> [shield\_region](#input\_shield\_region) | Which Fastly shield region to use. Should correspond with the shield code. | `string` | n/a | yes |
 | <a name="input_ssl_hostname"></a> [ssl\_hostname](#input\_ssl\_hostname) | Hostname to use for SSL verification (if different from 'hostname'). | `string` | `""` | no |
+| <a name="input_vary_accept_language"></a> [vary\_accept\_language](#input\_vary\_accept\_language) | Whether to set 'Vary: Accept-Language' as a header with language-specific pages | `bool` | `true` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,7 @@ module "app" {
   datadog_region                = var.datadog_region
   datadog_service               = var.datadog_service
   datadog_token                 = var.datadog_token
+  vary_accept_language          = var.vary_accept_language
 }
 
 module "api" {

--- a/modules/app/main.tf
+++ b/modules/app/main.tf
@@ -12,7 +12,8 @@ locals {
 
   datadog_format         = replace(file("${path.module}/../../logging/datadog.json"), "__service__", var.datadog_service)
 
-  vcl_purge_auth = file("${path.module}/../../vcl/purge_auth.vcl")
+  vcl_purge_auth            = file("${path.module}/../../vcl/purge_auth.vcl")
+  vcl_vary_accept_language  = file("${path.module}/../../vcl/language_vary.vcl")
 }
 
 resource "fastly_service_vcl" "app_service" {
@@ -90,6 +91,17 @@ resource "fastly_service_vcl" "app_service" {
     content {
       name     = "Purge Authentication Header"
       content  = local.vcl_purge_auth
+      type     = "recv"
+      priority = 100
+    }
+  }
+
+  # Vary: Accept-Language header additions
+  dynamic "snippet" {
+    for_each = var.vary_accept_language ? [1] : []
+    content {
+      name     = "Vary Accept-Language"
+      content  = local.vcl_vary_accept_language
       type     = "recv"
       priority = 100
     }

--- a/modules/app/variables.tf
+++ b/modules/app/variables.tf
@@ -123,3 +123,9 @@ variable "datadog_region" {
     error_message = "Datadog region must be either US or EU."
   }
 }
+
+variable "vary_accept_language" {
+  description = "Whether to set 'Vary: Accept-Language' as a header with language-specific pages"
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -152,6 +152,12 @@ variable "datadog_region" {
   }
 }
 
+variable "vary_accept_language" {
+  description = "Whether to set 'Vary: Accept-Language' as a header with language-specific pages"
+  type        = bool
+  default     = true
+}
+
 # API
 
 variable "api_name" {

--- a/vcl/language_vary.vcl
+++ b/vcl/language_vary.vcl
@@ -1,0 +1,3 @@
+if ( req.url.path !~ "^/[a-zA-Z]{2}(?:-[a-zA-Z]{2})?/" ) {
+  req.http.Vary = "Accept-Language";
+}


### PR DESCRIPTION
This adds the header Vary: Accept-Language to any incoming request that does NOT have a language-specific page.

It checks this by looking for a URL that starts with either /xx/ or /xx-xx/ where x is any lower- or upper-case letter.
